### PR TITLE
chore: allow manual release as of now

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,6 +1,7 @@
 name: "Publish NPM Package"
 
 on:
+  workflow_dispatch:
   release:
     types: 
       - released


### PR DESCRIPTION
Until we figured out how we want to fully automatically release the versions, manual publish should be enabled.