### PR TITLE
docs: improve docs for `mirror:images`

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -48,3 +48,10 @@ jobs:
           commit: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           skipIfReleaseExists: true
+
+  # We can not use it as release trigger due to https://github.com/orgs/community/discussions/25281, so we call it directly after release
+  publish:
+    needs:
+      - release
+    uses: ./.github/workflows/on-release.yml
+    secrets: inherit

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -33,9 +33,9 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          if echo "$CHANGED_FILES" | grep -qE "README\.md.*package\.json|package\.json.*README\.md"; then
-            echo "You updated the README and the package.json. Good job!"
-          else
-            echo "You did either not update the README or not update the package.json or both. Do it."
+            if echo "$CHANGED_FILES" | grep -qE "README\.md.*package\.json|package\.json.*README\.md|README\.md.*CHANGELOG\.md|CHANGELOG\.md.*README\.md|package\.json.*CHANGELOG\.md|CHANGELOG\.md.*package\.json"; then
+            echo "You updated the README, CHANGELOG, and the package.json. Good job!"
+            else
+            echo "You did not update either the README, CHANGELOG, or the package.json, or all of them. Please do so."
             exit 1
-          fi
+            fi

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -33,9 +33,9 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-            if echo "$CHANGED_FILES" | grep -qE "README\.md.*package\.json|package\.json.*README\.md|README\.md.*CHANGELOG\.md|CHANGELOG\.md.*README\.md|package\.json.*CHANGELOG\.md|CHANGELOG\.md.*package\.json"; then
+          if echo "$CHANGED_FILES" | grep -qE "README\.md.*package\.json|package\.json.*README\.md|README\.md.*CHANGELOG\.md|CHANGELOG\.md.*README\.md|package\.json.*CHANGELOG\.md|CHANGELOG\.md.*package\.json"; then
             echo "You updated the README, CHANGELOG, and the package.json. Good job!"
-            else
+          else
             echo "You did not update either the README, CHANGELOG, or the package.json, or all of them. Please do so."
-            exit 1
-            fi
+          exit 1
+          fi

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -2,12 +2,8 @@ name: "Publish NPM Package"
 
 on:
   workflow_dispatch:
-  release:
-    types: 
-      - released
-    branches:
-      - main
-
+  workflow_call:
+    
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -5,6 +5,8 @@ on:
   release:
     types: 
       - released
+    branches:
+      - main
 
 jobs:
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.3.1] - 2024-08-05
+
+### Changed
+
+- Automatically trigger publish when a release is created.
+
+#### `mirror:images`
+- Add example file [`mirror-images.schema.yaml`](./examples/mirror-images.schema.yaml)to documentation.
+- Improve description of the command itself. Ensuring immutability is not yet enforced and might be added later.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Unique CLI, wrapping the most common actions needed by Uniques clients into a si
 > [!NOTE]
 > The Unique CLI is incubating. Until version 1.0.0 also minor versions can contain breaking changes 💥
 
+<!-- toc -->
+
+<!-- tocstop -->
+
 ## Contributing
 See the [contributing guide](CONTRIBUTING.md) for more information.
 
@@ -26,13 +30,17 @@ USAGE
 ## Commands
 <!-- commands -->
 * [`qcli help [COMMAND]`](#qcli-help-command)
+* [`qcli m i`](#qcli-m-i)
 * [`qcli mirror images`](#qcli-mirror-images)
 * [`qcli plugins`](#qcli-plugins)
+* [`qcli plugins add PLUGIN`](#qcli-plugins-add-plugin)
 * [`qcli plugins:inspect PLUGIN...`](#qcli-pluginsinspect-plugin)
 * [`qcli plugins install PLUGIN`](#qcli-plugins-install-plugin)
 * [`qcli plugins link PATH`](#qcli-plugins-link-path)
+* [`qcli plugins remove [PLUGIN]`](#qcli-plugins-remove-plugin)
 * [`qcli plugins reset`](#qcli-plugins-reset)
 * [`qcli plugins uninstall [PLUGIN]`](#qcli-plugins-uninstall-plugin)
+* [`qcli plugins unlink [PLUGIN]`](#qcli-plugins-unlink-plugin)
 * [`qcli plugins update`](#qcli-plugins-update)
 
 ## `qcli help [COMMAND]`
@@ -55,9 +63,57 @@ DESCRIPTION
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.6/src/commands/help.ts)_
 
+## `qcli m i`
+
+Pulls images from a source, retags them, and pushes them to a new registry. For security reasons, the active session must be preemptively logged in to both docker registries. The "imageListFile" flag specifies which images to mirror. You can find an example config file in https://github.com/Unique-AG/cli/tree/main/examples.
+
+```
+USAGE
+  $ qcli m i -f <value> [-b <value>] [-s <value>] [-t <value>]
+
+FLAGS
+  -b, --batchSize=<value>       [default: 2] Number of images to transfer in a single batch in parallel. The higher the
+                                number, the more resources will be consumed.
+  -f, --imageListFile=<value>   (required) [default: examples/mirror-images.schema.yaml] Path to file that contains a
+                                list of images to mirror.
+  -s, --sourceRegistry=<value>  Source registry from where the images will be pulled, this overrides the value specified
+                                in the imageListFile.
+  -t, --targetRegistry=<value>  Target registry where the images will go, this overrides the value specified in the
+                                imageListFile.
+
+DESCRIPTION
+  Pulls images from a source, retags them, and pushes them to a new registry. For security reasons, the active session
+  must be preemptively logged in to both docker registries. The "imageListFile" flag specifies which images to mirror.
+  You can find an example config file in https://github.com/Unique-AG/cli/tree/main/examples.
+
+ALIASES
+  $ qcli m i
+
+EXAMPLES
+  export SOURCE_DOCKER_REGISTRY: <VALUE>
+  export SOURCE_DOCKER_USERNAME: <SENSITIVE_VALUE>
+  export SOURCE_DOCKER_PASSWORD: <SENSITIVE_VALUE>
+  export TARGET_DOCKER_REGISTRY: <VALUE>
+  export TARGET_DOCKER_USERNAME: <SENSITIVE_VALUE>
+  export TARGET_DOCKER_PASSWORD: <SENSITIVE_VALUE>
+  docker login $SOURCE_DOCKER_REGISTRY -u $SOURCE_DOCKER_USERNAME -p $SOURCE_DOCKER_PASSWORD
+  docker login $TARGET_DOCKER_REGISTRY -u $TARGET_DOCKER_USERNAME -p $TARGET_DOCKER_PASSWORD
+  $ qcli m i
+
+  export SOURCE_DOCKER_REGISTRY: <VALUE>
+  export SOURCE_DOCKER_USERNAME: <SENSITIVE_VALUE>
+  export SOURCE_DOCKER_PASSWORD: <SENSITIVE_VALUE>
+  export TARGET_DOCKER_REGISTRY: <VALUE>
+  export TARGET_DOCKER_USERNAME: <SENSITIVE_VALUE>
+  export TARGET_DOCKER_PASSWORD: <SENSITIVE_VALUE>
+  docker login $SOURCE_DOCKER_REGISTRY -u $SOURCE_DOCKER_USERNAME -p $SOURCE_DOCKER_PASSWORD
+  az acr login --name polishednight8579
+  $ qcli m i
+```
+
 ## `qcli mirror images`
 
-Pulls images from a source, retags them, and pushes them to a new registry. For security reasons, the active session must be preemptively logged in to both docker registries. The command treats images as immutable and will refuse to retag an image if it already exists in the target registry.
+Pulls images from a source, retags them, and pushes them to a new registry. For security reasons, the active session must be preemptively logged in to both docker registries. The "imageListFile" flag specifies which images to mirror. You can find an example config file in https://github.com/Unique-AG/cli/tree/main/examples.
 
 ```
 USAGE
@@ -75,8 +131,8 @@ FLAGS
 
 DESCRIPTION
   Pulls images from a source, retags them, and pushes them to a new registry. For security reasons, the active session
-  must be preemptively logged in to both docker registries. The command treats images as immutable and will refuse to
-  retag an image if it already exists in the target registry.
+  must be preemptively logged in to both docker registries. The "imageListFile" flag specifies which images to mirror.
+  You can find an example config file in https://github.com/Unique-AG/cli/tree/main/examples.
 
 ALIASES
   $ qcli m i
@@ -127,6 +183,53 @@ EXAMPLES
 ```
 
 _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.7/src/commands/plugins/index.ts)_
+
+## `qcli plugins add PLUGIN`
+
+Installs a plugin into qcli.
+
+```
+USAGE
+  $ qcli plugins add PLUGIN... [--json] [-f] [-h] [-s | -v]
+
+ARGUMENTS
+  PLUGIN...  Plugin to install.
+
+FLAGS
+  -f, --force    Force npm to fetch remote resources even if a local copy exists on disk.
+  -h, --help     Show CLI help.
+  -s, --silent   Silences npm output.
+  -v, --verbose  Show verbose npm output.
+
+GLOBAL FLAGS
+  --json  Format output as json.
+
+DESCRIPTION
+  Installs a plugin into qcli.
+
+  Uses npm to install plugins.
+
+  Installation of a user-installed plugin will override a core plugin.
+
+  Use the QCLI_NPM_LOG_LEVEL environment variable to set the npm loglevel.
+  Use the QCLI_NPM_REGISTRY environment variable to set the npm registry.
+
+ALIASES
+  $ qcli plugins add
+
+EXAMPLES
+  Install a plugin from npm registry.
+
+    $ qcli plugins add myplugin
+
+  Install a plugin from a github url.
+
+    $ qcli plugins add https://github.com/someuser/someplugin
+
+  Install a plugin from a github slug.
+
+    $ qcli plugins add someuser/someplugin
+```
 
 ## `qcli plugins:inspect PLUGIN...`
 
@@ -234,6 +337,32 @@ EXAMPLES
 
 _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.7/src/commands/plugins/link.ts)_
 
+## `qcli plugins remove [PLUGIN]`
+
+Removes a plugin from the CLI.
+
+```
+USAGE
+  $ qcli plugins remove [PLUGIN...] [-h] [-v]
+
+ARGUMENTS
+  PLUGIN...  plugin to uninstall
+
+FLAGS
+  -h, --help     Show CLI help.
+  -v, --verbose
+
+DESCRIPTION
+  Removes a plugin from the CLI.
+
+ALIASES
+  $ qcli plugins unlink
+  $ qcli plugins remove
+
+EXAMPLES
+  $ qcli plugins remove myplugin
+```
+
 ## `qcli plugins reset`
 
 Remove all user-installed and linked plugins.
@@ -277,6 +406,32 @@ EXAMPLES
 
 _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.7/src/commands/plugins/uninstall.ts)_
 
+## `qcli plugins unlink [PLUGIN]`
+
+Removes a plugin from the CLI.
+
+```
+USAGE
+  $ qcli plugins unlink [PLUGIN...] [-h] [-v]
+
+ARGUMENTS
+  PLUGIN...  plugin to uninstall
+
+FLAGS
+  -h, --help     Show CLI help.
+  -v, --verbose
+
+DESCRIPTION
+  Removes a plugin from the CLI.
+
+ALIASES
+  $ qcli plugins unlink
+  $ qcli plugins remove
+
+EXAMPLES
+  $ qcli plugins unlink myplugin
+```
+
 ## `qcli plugins update`
 
 Update installed plugins.
@@ -295,7 +450,6 @@ DESCRIPTION
 
 _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.7/src/commands/plugins/update.ts)_
 <!-- commandsstop -->
-## Table of contents
-<!-- toc -->
 
-<!-- tocstop -->
+## Examples
+For some commands, you find example files in [examples](https://github.com/Unique-AG/cli/tree/main/examples) folder. Most commands with example files also have a default example file that is used if no file is specified.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ npm install -g @unique-ag/cli
 $ qcli COMMAND
 running command...
 $ qcli (--version)
-@unique-ag/cli/0.3.0 darwin-arm64 node-v20.14.0
+@unique-ag/cli/0.3.1 darwin-arm64 node-v20.14.0
 $ qcli --help [COMMAND]
 USAGE
   $ qcli COMMAND
@@ -159,7 +159,7 @@ EXAMPLES
   $ qcli mirror images
 ```
 
-_See code: [src/commands/mirror/images.ts](https://github.com/Unique-AG/cli/blob/v0.3.0/src/commands/mirror/images.ts)_
+_See code: [src/commands/mirror/images.ts](https://github.com/Unique-AG/cli/blob/v0.3.1/src/commands/mirror/images.ts)_
 
 ## `qcli plugins`
 

--- a/README.md
+++ b/README.md
@@ -30,17 +30,13 @@ USAGE
 ## Commands
 <!-- commands -->
 * [`qcli help [COMMAND]`](#qcli-help-command)
-* [`qcli m i`](#qcli-m-i)
 * [`qcli mirror images`](#qcli-mirror-images)
 * [`qcli plugins`](#qcli-plugins)
-* [`qcli plugins add PLUGIN`](#qcli-plugins-add-plugin)
 * [`qcli plugins:inspect PLUGIN...`](#qcli-pluginsinspect-plugin)
 * [`qcli plugins install PLUGIN`](#qcli-plugins-install-plugin)
 * [`qcli plugins link PATH`](#qcli-plugins-link-path)
-* [`qcli plugins remove [PLUGIN]`](#qcli-plugins-remove-plugin)
 * [`qcli plugins reset`](#qcli-plugins-reset)
 * [`qcli plugins uninstall [PLUGIN]`](#qcli-plugins-uninstall-plugin)
-* [`qcli plugins unlink [PLUGIN]`](#qcli-plugins-unlink-plugin)
 * [`qcli plugins update`](#qcli-plugins-update)
 
 ## `qcli help [COMMAND]`
@@ -62,54 +58,6 @@ DESCRIPTION
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.6/src/commands/help.ts)_
-
-## `qcli m i`
-
-Pulls images from a source, retags them, and pushes them to a new registry. For security reasons, the active session must be preemptively logged in to both docker registries. The "imageListFile" flag specifies which images to mirror. You can find an example config file in https://github.com/Unique-AG/cli/tree/main/examples.
-
-```
-USAGE
-  $ qcli m i -f <value> [-b <value>] [-s <value>] [-t <value>]
-
-FLAGS
-  -b, --batchSize=<value>       [default: 2] Number of images to transfer in a single batch in parallel. The higher the
-                                number, the more resources will be consumed.
-  -f, --imageListFile=<value>   (required) [default: examples/mirror-images.schema.yaml] Path to file that contains a
-                                list of images to mirror.
-  -s, --sourceRegistry=<value>  Source registry from where the images will be pulled, this overrides the value specified
-                                in the imageListFile.
-  -t, --targetRegistry=<value>  Target registry where the images will go, this overrides the value specified in the
-                                imageListFile.
-
-DESCRIPTION
-  Pulls images from a source, retags them, and pushes them to a new registry. For security reasons, the active session
-  must be preemptively logged in to both docker registries. The "imageListFile" flag specifies which images to mirror.
-  You can find an example config file in https://github.com/Unique-AG/cli/tree/main/examples.
-
-ALIASES
-  $ qcli m i
-
-EXAMPLES
-  export SOURCE_DOCKER_REGISTRY: <VALUE>
-  export SOURCE_DOCKER_USERNAME: <SENSITIVE_VALUE>
-  export SOURCE_DOCKER_PASSWORD: <SENSITIVE_VALUE>
-  export TARGET_DOCKER_REGISTRY: <VALUE>
-  export TARGET_DOCKER_USERNAME: <SENSITIVE_VALUE>
-  export TARGET_DOCKER_PASSWORD: <SENSITIVE_VALUE>
-  docker login $SOURCE_DOCKER_REGISTRY -u $SOURCE_DOCKER_USERNAME -p $SOURCE_DOCKER_PASSWORD
-  docker login $TARGET_DOCKER_REGISTRY -u $TARGET_DOCKER_USERNAME -p $TARGET_DOCKER_PASSWORD
-  $ qcli m i
-
-  export SOURCE_DOCKER_REGISTRY: <VALUE>
-  export SOURCE_DOCKER_USERNAME: <SENSITIVE_VALUE>
-  export SOURCE_DOCKER_PASSWORD: <SENSITIVE_VALUE>
-  export TARGET_DOCKER_REGISTRY: <VALUE>
-  export TARGET_DOCKER_USERNAME: <SENSITIVE_VALUE>
-  export TARGET_DOCKER_PASSWORD: <SENSITIVE_VALUE>
-  docker login $SOURCE_DOCKER_REGISTRY -u $SOURCE_DOCKER_USERNAME -p $SOURCE_DOCKER_PASSWORD
-  az acr login --name polishednight8579
-  $ qcli m i
-```
 
 ## `qcli mirror images`
 
@@ -183,53 +131,6 @@ EXAMPLES
 ```
 
 _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.7/src/commands/plugins/index.ts)_
-
-## `qcli plugins add PLUGIN`
-
-Installs a plugin into qcli.
-
-```
-USAGE
-  $ qcli plugins add PLUGIN... [--json] [-f] [-h] [-s | -v]
-
-ARGUMENTS
-  PLUGIN...  Plugin to install.
-
-FLAGS
-  -f, --force    Force npm to fetch remote resources even if a local copy exists on disk.
-  -h, --help     Show CLI help.
-  -s, --silent   Silences npm output.
-  -v, --verbose  Show verbose npm output.
-
-GLOBAL FLAGS
-  --json  Format output as json.
-
-DESCRIPTION
-  Installs a plugin into qcli.
-
-  Uses npm to install plugins.
-
-  Installation of a user-installed plugin will override a core plugin.
-
-  Use the QCLI_NPM_LOG_LEVEL environment variable to set the npm loglevel.
-  Use the QCLI_NPM_REGISTRY environment variable to set the npm registry.
-
-ALIASES
-  $ qcli plugins add
-
-EXAMPLES
-  Install a plugin from npm registry.
-
-    $ qcli plugins add myplugin
-
-  Install a plugin from a github url.
-
-    $ qcli plugins add https://github.com/someuser/someplugin
-
-  Install a plugin from a github slug.
-
-    $ qcli plugins add someuser/someplugin
-```
 
 ## `qcli plugins:inspect PLUGIN...`
 
@@ -337,32 +238,6 @@ EXAMPLES
 
 _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.7/src/commands/plugins/link.ts)_
 
-## `qcli plugins remove [PLUGIN]`
-
-Removes a plugin from the CLI.
-
-```
-USAGE
-  $ qcli plugins remove [PLUGIN...] [-h] [-v]
-
-ARGUMENTS
-  PLUGIN...  plugin to uninstall
-
-FLAGS
-  -h, --help     Show CLI help.
-  -v, --verbose
-
-DESCRIPTION
-  Removes a plugin from the CLI.
-
-ALIASES
-  $ qcli plugins unlink
-  $ qcli plugins remove
-
-EXAMPLES
-  $ qcli plugins remove myplugin
-```
-
 ## `qcli plugins reset`
 
 Remove all user-installed and linked plugins.
@@ -405,32 +280,6 @@ EXAMPLES
 ```
 
 _See code: [@oclif/plugin-plugins](https://github.com/oclif/plugin-plugins/blob/v5.3.7/src/commands/plugins/uninstall.ts)_
-
-## `qcli plugins unlink [PLUGIN]`
-
-Removes a plugin from the CLI.
-
-```
-USAGE
-  $ qcli plugins unlink [PLUGIN...] [-h] [-v]
-
-ARGUMENTS
-  PLUGIN...  plugin to uninstall
-
-FLAGS
-  -h, --help     Show CLI help.
-  -v, --verbose
-
-DESCRIPTION
-  Removes a plugin from the CLI.
-
-ALIASES
-  $ qcli plugins unlink
-  $ qcli plugins remove
-
-EXAMPLES
-  $ qcli plugins unlink myplugin
-```
 
 ## `qcli plugins update`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unique-ag/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unique-ag/cli",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unique-ag/cli",
   "description": "Unique CLI, wrapping the most common actions needed by Uniques clients into a single command line tool.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Unique AG",
   "bin": {
     "qcli": "./bin/run.js"

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "lint": "eslint . --ext .ts",
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "npm run lint",
-    "prepack": "oclif manifest && oclif readme",
-    "readme": "npm run build && oclif readme",
+    "prepack": "oclif manifest && npm run readme",
+    "readme": "npm run build && oclif readme --no-aliases",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "npm run readme && git add README.md"
   },

--- a/package.json
+++ b/package.json
@@ -63,13 +63,15 @@
   },
   "repository": "Unique-AG/cli",
   "scripts": {
-    "build": "shx rm -rf dist && tsc -b",
+    "build": "npm run clean && tsc -b",
+    "clean": "shx rm -rf dist",
     "lint": "eslint . --ext .ts",
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "npm run lint",
     "prepack": "oclif manifest && oclif readme",
+    "readme": "npm run build && oclif readme",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
-    "version": "oclif readme && git add README.md"
+    "version": "npm run readme && git add README.md"
   },
   "types": "dist/index.d.ts"
 }

--- a/src/commands/mirror/images.ts
+++ b/src/commands/mirror/images.ts
@@ -21,7 +21,7 @@ const schema = Joi.object({
 export default class MirrorImages extends Command {
   static aliases = ['m:i'];
   static args = {}
-  static description = 'Pulls images from a source, retags them, and pushes them to a new registry. For security reasons, the active session must be preemptively logged in to both docker registries. The command treats images as immutable and will refuse to retag an image if it already exists in the target registry.'
+  static description = 'Pulls images from a source, retags them, and pushes them to a new registry. For security reasons, the active session must be preemptively logged in to both docker registries. The "imageListFile" flag specifies which images to mirror. You can find an example config file in https://github.com/Unique-AG/cli/tree/main/examples.'
   static examples = [`
 export SOURCE_DOCKER_REGISTRY: <VALUE>
 export SOURCE_DOCKER_USERNAME: <SENSITIVE_VALUE>


### PR DESCRIPTION
## [0.3.1] - 2024-08-05

 ### Changed

 - Automatically trigger publish when a release is created.

 #### `mirror:images`
 - Add example file [`mirror-images.schema.yaml`](./examples/mirror-images.schema.yaml)to documentation.
 - Improve description of the command itself. Ensuring immutability is not yet enforced and might be added later.