### PR TITLE
feat: add push-plugin selection to mirror:charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 2024-08-14
+
+### Changed
+#### `mirror:charts`
+- Command now supports flag `-p`/`--push-plugin` to select different helm plugins to push the charts to the destination registry. Refer to the command documentation for more detail.
+
 ## [0.4.0] - 2024-08-06
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ Refer to the [oclif documentation](https://oclif.io/docs/generator_commands#ocli
 
 ### Before the PR
 ```
-npm version [minor|patch]
-oclif readme
+# commit changes, then
+npm version
 ```
 
 Minimal actions will ensure that the `package.json` and `README.md` have changed as will the reviewers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Refer to the [oclif documentation](https://oclif.io/docs/generator_commands#ocli
 ### Before the PR
 ```
 # commit changes, then
-npm version
+npm version [minor|patch]
 ```
 
 Minimal actions will ensure that the `package.json` and `README.md` have changed as will the reviewers.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ npm install -g @unique-ag/cli
 $ qcli COMMAND
 running command...
 $ qcli (--version)
-@unique-ag/cli/0.4.0 darwin-arm64 node-v20.14.0
+@unique-ag/cli/0.4.1 darwin-arm64 node-v20.14.0
 $ qcli --help [COMMAND]
 USAGE
   $ qcli COMMAND
@@ -66,12 +66,15 @@ Pulls charts from a source and pushes them to a new registry.
 
 ```
 USAGE
-  $ qcli mirror charts -f <value> [-k] [-s <value>] [-t <value>]
+  $ qcli mirror charts -f <value> [-k] [-p <value>] [-s <value>] [-t <value>]
 
 FLAGS
   -f, --chart-list-file=<value>    (required) [default: examples/mirror-charts.schema.yaml] Path to file that contains a
                                    list of charts to mirror.
   -k, --keep                       If true, keeps the downloaded tarballs.
+  -p, --push-plugin=<value>        [default: push] Which plugin will be used to "push" charts to the target.
+                                   Defaults to native helm push but could be set to e.g. "cm-push" (for ChartMuseum).
+                                   Note: The plugin must be pre-installed using "helm plugin install".
   -s, --source-repository=<value>  Source repository from where the charts will be pulled, this overrides the value
                                    specified in the chart-list-file.
   -t, --target-repository=<value>  Target repository where the charts will go, this overrides the value specified in the
@@ -107,7 +110,7 @@ EXAMPLES
   $ qcli mirror charts
 ```
 
-_See code: [src/commands/mirror/charts.ts](https://github.com/Unique-AG/cli/blob/v0.4.0/src/commands/mirror/charts.ts)_
+_See code: [src/commands/mirror/charts.ts](https://github.com/Unique-AG/cli/blob/v0.4.1/src/commands/mirror/charts.ts)_
 
 ## `qcli mirror images`
 
@@ -157,7 +160,7 @@ EXAMPLES
   $ qcli mirror images
 ```
 
-_See code: [src/commands/mirror/images.ts](https://github.com/Unique-AG/cli/blob/v0.4.0/src/commands/mirror/images.ts)_
+_See code: [src/commands/mirror/images.ts](https://github.com/Unique-AG/cli/blob/v0.4.1/src/commands/mirror/images.ts)_
 
 ## `qcli plugins`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unique-ag/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unique-ag/cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unique-ag/cli",
   "description": "Unique CLI, wrapping the most common actions needed by Uniques clients into a single command line tool.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Unique AG",
   "bin": {
     "qcli": "./bin/run.js"

--- a/src/commands/mirror/charts.ts
+++ b/src/commands/mirror/charts.ts
@@ -60,6 +60,13 @@ az acr login --name <REGISTRY_NAME>
       char: 'k',
       description: 'If true, keeps the downloaded tarballs.'
     }),
+    'push-plugin': Flags.string({
+      char: 'p',
+      default: 'push',
+      description: `Which plugin will be used to "push" charts to the target. 
+Defaults to native helm push but could be set to e.g. "cm-push" (for ChartMuseum).
+Note: The plugin must be pre-installed using "helm plugin install".`
+    }),
     'source-repository': Flags.string({
       char: 's',
       description: 'Source repository from where the charts will be pulled, this overrides the value specified in the chart-list-file.'
@@ -78,6 +85,7 @@ az acr login --name <REGISTRY_NAME>
     const chartListFile = this.flags['chart-list-file'];
     const sourceRepository = this.flags['source-repository'];
     const targetRepository = this.flags['target-repository'];
+    const pushPlugin = this.flags['push-plugin'];
     const { keep } = this.flags;
     const clipboard = temporaryDirectory({ prefix: TEMPY_PREFIX });
 
@@ -120,7 +128,7 @@ az acr login --name <REGISTRY_NAME>
 
         this.log(`Pulling ${ux.colorize(LIGHT_BLUE, `${name}`)} from ${ux.colorize(LIGHT_BLUE, source)} and pushing it to ${ux.colorize(LIGHT_BLUE, target)}.`);
         const tgzPath = await helmPull({ chartName, chartPath, clipboard, repository: source, version });
-        await helmPush({ nestedPath: chartPath, repository: target, tgzPath });
+        await helmPush({ nestedPath: chartPath, pushPlugin, repository: target, tgzPath });
       }));
       
       const rejectedOperations = operations.filter((operation) => operation.status === 'rejected');

--- a/src/utils/helm.ts
+++ b/src/utils/helm.ts
@@ -6,7 +6,7 @@ export async function helmPull({ chartName,chartPath, clipboard, repository, ver
   return `${clipboard}/${chartName}-${version}.tgz`;
 }
 
-export async function helmPush({ nestedPath, repository, tgzPath }: { nestedPath?: string, repository: string, tgzPath: string }): Promise<void> {
-  const cmd = `helm push ${tgzPath} oci://${repository}${nestedPath ? `/${nestedPath}` : ''}`;
+export async function helmPush({ nestedPath, pushPlugin, repository, tgzPath }: { nestedPath?: string, pushPlugin: string, repository: string, tgzPath: string }): Promise<void> {
+  const cmd = `helm ${pushPlugin} ${tgzPath} oci://${repository}${nestedPath ? `/${nestedPath}` : ''}`;
   await execPromisified(cmd);
 }


### PR DESCRIPTION
Lets users select between different helm plugins to push the charts.