### PR TITLE
ci(tool/github): add pinned actions verification workflow

### DIFF
--- a/.github/workflows/github.policies.verify.pinned-actions.yaml
+++ b/.github/workflows/github.policies.verify.pinned-actions.yaml
@@ -1,0 +1,28 @@
+name: "GitHub · Policies · Verify · Pinned Actions"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+jobs:
+  check-pinned-actions:
+    name: Verify action SHAs are pinned
+    runs-on: pulsar-spark
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify pinned actions
+        uses: unique-ag/actions/github/policies/verify-pinned-actions@84a4f60c0a56daae108b22e096b72bb10f476d08 # main

--- a/.github/workflows/github.policies.verify.pinned-actions.yaml
+++ b/.github/workflows/github.policies.verify.pinned-actions.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   check-pinned-actions:
     name: Verify action SHAs are pinned
-    runs-on: pulsar-spark
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - name: Checkout repository

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -19,8 +19,8 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       - name: Check if version already exists
         id: version-check
         run: |
@@ -40,7 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Github Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
         with:
           name: ${{ steps.version-check.outputs.tag }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -8,13 +8,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: latest
       - run: npm install
       - run: npm run build
-      - uses: JS-DevTools/npm-publish@v3
+      - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c # v3
         with:
           access: public
           token: ${{ secrets.NPMJS_GRANULAR_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds the `github.policies.verify.pinned-actions.yaml` workflow to enforce SHA-pinned GitHub Actions
- Runs on PRs to `main` that modify `.github/workflows/**` or `.github/actions/**`
- Uses `unique-ag/actions/github/policies/verify-pinned-actions` to verify all actions are pinned to commit SHAs

## Test plan

- [ ] Verify workflow file is valid YAML
- [ ] Open a test PR modifying a workflow to confirm the check runs